### PR TITLE
Add import/export actions for fluffy config

### DIFF
--- a/TMessagesProj/src/main/java/org/ushastoe/fluffy/fluffyConfig.java
+++ b/TMessagesProj/src/main/java/org/ushastoe/fluffy/fluffyConfig.java
@@ -15,6 +15,7 @@ import org.ushastoe.fluffy.helpers.BaseIconSet;
 import org.ushastoe.fluffy.helpers.EmptyIconSet;
 import org.ushastoe.fluffy.helpers.SolarIconSet;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -143,10 +144,25 @@ public final class fluffyConfig {
 
     private fluffyConfig() {}
 
+    public static String getPreferencesFileName() {
+        return PREFS_NAME + ".xml";
+    }
+
+    public static File getPreferencesFile() {
+        Context context = ApplicationLoader.applicationContext;
+        File prefsDir = new File(context.getApplicationInfo().dataDir, "shared_prefs");
+        return new File(prefsDir, getPreferencesFileName());
+    }
+
     /**
      * Инициализирует конфигурацию, загружая настройки из SharedPreferences.
      */
     public static void init() {
+        preferences = ApplicationLoader.applicationContext.getSharedPreferences(PREFS_NAME, Activity.MODE_PRIVATE);
+        load();
+    }
+
+    public static void reloadFromDisk() {
         preferences = ApplicationLoader.applicationContext.getSharedPreferences(PREFS_NAME, Activity.MODE_PRIVATE);
         load();
     }

--- a/TMessagesProj/src/main/res/values/fluffy_strings.xml
+++ b/TMessagesProj/src/main/res/values/fluffy_strings.xml
@@ -18,6 +18,14 @@
     <string name="formatTime">Format time with seconds</string>
     <string name="CloudflareCredentials">Cloudflare credentials</string>
     <string name="SendLargePhoto">Send Large Photo</string>
+    <string name="ExportFluffyConfig">Export fluffyConfig.xml</string>
+    <string name="ImportFluffyConfig">Import fluffyConfig.xml</string>
+    <string name="ExportFluffyConfigSuccess">Configuration exported</string>
+    <string name="ExportFluffyConfigError">Failed to export configuration</string>
+    <string name="ImportFluffyConfigSuccess">Configuration imported</string>
+    <string name="ImportFluffyConfigError">Failed to import configuration</string>
+    <string name="ImportFluffyConfigWrongFile">Please select fluffyConfig.xml file</string>
+    <string name="FluffyConfigFileMissing">Configuration file is missing</string>
     <string name="CloudflareCredentialsNotSet">Cloudflare credentials are not configured.</string>
     <string name="CloudflareAccountID">Account ID</string>
     <string name="CloudflareAPIToken">API Token</string>


### PR DESCRIPTION
## Summary
- add dedicated actions in general settings to export and import the fluffyConfig.xml preferences
- provide helper APIs on fluffyConfig to expose the preferences file path and reload values after import
- localize new strings and show bulletins describing export/import status

## Testing
- ./gradlew :TMessagesProj:lint *(fails: project build script expects non-null resValue parameter unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_68ca5639212c83269c32595c99036aa2